### PR TITLE
Potential fix for code scanning alert no. 3: Log entries created from user input

### DIFF
--- a/CigarCertifierAPI/Services/EmailService.cs
+++ b/CigarCertifierAPI/Services/EmailService.cs
@@ -61,7 +61,8 @@ namespace CigarCertifierAPI.Services
                 throw new InvalidOperationException($"Email sending failed with status code: {response.StatusCode}. Response Body: {responseBody}");
             }
 
-            _logger.LogInformation("Email sent successfully to {RecipientEmail}", recipientEmail);
+            var sanitizedRecipientEmail = recipientEmail.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            _logger.LogInformation("Email sent successfully to {RecipientEmail}", sanitizedRecipientEmail);
         }
     }
 

--- a/CigarCertifierAPI/Services/EmailService.cs
+++ b/CigarCertifierAPI/Services/EmailService.cs
@@ -61,8 +61,7 @@ namespace CigarCertifierAPI.Services
                 throw new InvalidOperationException($"Email sending failed with status code: {response.StatusCode}. Response Body: {responseBody}");
             }
 
-            var sanitizedRecipientEmail = recipientEmail.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
-            _logger.LogInformation("Email sent successfully to {RecipientEmail}", sanitizedRecipientEmail);
+            _logger.LogInformation("Email sent successfully.");
         }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ladbon/cigarcert/security/code-scanning/3](https://github.com/Ladbon/cigarcert/security/code-scanning/3)

To fix the problem, we need to sanitize the `recipientEmail` before logging it. This can be done by removing any newline characters from the `recipientEmail` to prevent log forging. We can use the `String.Replace` method to achieve this.

1. Identify the line where `recipientEmail` is logged.
2. Sanitize the `recipientEmail` by replacing newline characters with an empty string before logging it.
3. Ensure that the fix does not alter the existing functionality of the method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
