### PR TITLE
Potential fix for code scanning alert no. 7: Exposure of private information

### DIFF
--- a/CigarCertifierAPI/Services/EmailService.cs
+++ b/CigarCertifierAPI/Services/EmailService.cs
@@ -61,7 +61,7 @@ namespace CigarCertifierAPI.Services
                 throw new InvalidOperationException($"Email sending failed with status code: {response.StatusCode}. Response Body: {responseBody}");
             }
 
-            _logger.LogInformation("Email sent successfully to {RecipientEmail}", recipientEmail);
+            _logger.LogInformation("Email sent successfully.");
         }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ladbon/cigarcert/security/code-scanning/7](https://github.com/Ladbon/cigarcert/security/code-scanning/7)

To fix the problem, we should avoid logging the `recipientEmail` directly. Instead, we can log a generic success message without including the email address. This ensures that no sensitive information is exposed in the logs.

- Modify the `_logger.LogInformation` call on line 64 to remove the `recipientEmail` parameter.
- Update the log message to a more generic one that does not include any sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
