### PR TITLE
Potential fix for code scanning alert no. 4: Clear text storage of sensitive information

### DIFF
--- a/CigarCertifierAPI/Services/LoggerService.cs
+++ b/CigarCertifierAPI/Services/LoggerService.cs
@@ -60,8 +60,9 @@ namespace CigarCertifierAPI.Services
         {
             try
             {
+                var protectedMessage = ProtectSensitiveInformation(message, "LogWarning");
                 var protectedArgs = args.Select(arg => arg is string ? ProtectSensitiveInformation(arg.ToString(), "LogWarning") : arg).ToArray();
-                _logger.LogWarning(message, protectedArgs);
+                _logger.LogWarning(protectedMessage, protectedArgs);
             }
             catch (Exception ex)
             {

--- a/CigarCertifierAPI/Services/LoggerService.cs
+++ b/CigarCertifierAPI/Services/LoggerService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
-
+using System.Web.Security;
+using System.Text;
 namespace CigarCertifierAPI.Services
 {
     public class LoggerService
@@ -44,16 +45,23 @@ namespace CigarCertifierAPI.Services
             _logger = logger;
         }
 
+        private string ProtectSensitiveInformation(string value, string type)
+        {
+            return Convert.ToBase64String(MachineKey.Protect(Encoding.UTF8.GetBytes(value), type));
+        }
+
         private void LogEvent(string message, params object[] args)
         {
-            _logger.LogInformation(message, args);
+            var protectedArgs = args.Select(arg => arg is string ? ProtectSensitiveInformation(arg.ToString(), "LogEvent") : arg).ToArray();
+            _logger.LogInformation(message, protectedArgs);
         }
 
         private void LogWarning(string message, params object[] args)
         {
             try
             {
-                _logger.LogWarning(message, args);
+                var protectedArgs = args.Select(arg => arg is string ? ProtectSensitiveInformation(arg.ToString(), "LogWarning") : arg).ToArray();
+                _logger.LogWarning(message, protectedArgs);
             }
             catch (Exception ex)
             {
@@ -70,7 +78,8 @@ namespace CigarCertifierAPI.Services
         {
             try
             {
-                _logger.LogDebug(message, args);
+                var protectedArgs = args.Select(arg => arg is string ? ProtectSensitiveInformation(arg.ToString(), "LogDebug") : arg).ToArray();
+                _logger.LogDebug(message, protectedArgs);
             }
             catch (Exception ex)
             {

--- a/CigarCertifierAPI/Services/LoggerService.cs
+++ b/CigarCertifierAPI/Services/LoggerService.cs
@@ -52,8 +52,9 @@ namespace CigarCertifierAPI.Services
 
         private void LogEvent(string message, params object[] args)
         {
+            var protectedMessage = ProtectSensitiveInformation(message, "LogEvent");
             var protectedArgs = args.Select(arg => arg is string ? ProtectSensitiveInformation(arg.ToString(), "LogEvent") : arg).ToArray();
-            _logger.LogInformation(message, protectedArgs);
+            _logger.LogInformation(protectedMessage, protectedArgs);
         }
 
         private void LogWarning(string message, params object[] args)
@@ -66,7 +67,7 @@ namespace CigarCertifierAPI.Services
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An error occurred while logging a warning: {Message}", message);
+                _logger.LogError(ex, "An error occurred while logging a warning: {Message}", ProtectSensitiveInformation(message, "LogWarning"));
             }
         }
 
@@ -79,12 +80,13 @@ namespace CigarCertifierAPI.Services
         {
             try
             {
+                var protectedMessage = ProtectSensitiveInformation(message, "LogDebug");
                 var protectedArgs = args.Select(arg => arg is string ? ProtectSensitiveInformation(arg.ToString(), "LogDebug") : arg).ToArray();
-                _logger.LogDebug(message, protectedArgs);
+                _logger.LogDebug(protectedMessage, protectedArgs);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An error occurred while logging a debug message: {Message}", message);
+                _logger.LogError(ex, "An error occurred while logging a debug message: {Message}", ProtectSensitiveInformation(message, "LogDebug"));
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ladbon/cigarcert/security/code-scanning/4](https://github.com/Ladbon/cigarcert/security/code-scanning/4)

To fix the problem, we need to ensure that sensitive information is not logged in clear text. We can achieve this by encrypting the sensitive information before logging it. In this case, we will use the `System.Web.Security.MachineKey` class to protect the sensitive information before logging it.

1. Create a method to protect sensitive information using `MachineKey.Protect`.
2. Update the `LogEvent` method to use this protection method for sensitive information.
3. Ensure that the protection method is used consistently for all sensitive information being logged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
