### PR TITLE
Potential fix for code scanning alert no. 6: Clear text storage of sensitive information

### DIFF
--- a/CigarCertifierAPI/Services/LoggerService.cs
+++ b/CigarCertifierAPI/Services/LoggerService.cs
@@ -53,7 +53,7 @@ namespace CigarCertifierAPI.Services
         {
             try
             {
-                _logger.LogWarning(message, args);
+                _logger.LogWarning(RedactSensitiveData(message), args);
             }
             catch (Exception ex)
             {
@@ -249,6 +249,12 @@ namespace CigarCertifierAPI.Services
                     _logger.LogWarning("Validation error on {Key}: {ErrorMessage}", modelStateEntry.Key, error.ErrorMessage);
                 }
             }
+        }
+        private string RedactSensitiveData(string message)
+        {
+            // Implement redaction logic here
+            // For example, replace email addresses with [REDACTED]
+            return message.Replace("email", "[REDACTED]");
         }
     }
 }

--- a/CigarCertifierAPI/Services/LoggerService.cs
+++ b/CigarCertifierAPI/Services/LoggerService.cs
@@ -252,9 +252,13 @@ namespace CigarCertifierAPI.Services
         }
         private string RedactSensitiveData(string message)
         {
-            // Implement redaction logic here
-            // For example, replace email addresses with [REDACTED]
-            return message.Replace("email", "[REDACTED]");
+            // Redact email addresses
+            message = System.Text.RegularExpressions.Regex.Replace(message, @"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}", "[REDACTED]");
+            // Redact tokens (assuming tokens are alphanumeric strings of a certain length)
+            message = System.Text.RegularExpressions.Regex.Replace(message, @"\b[a-zA-Z0-9]{32,}\b", "[REDACTED]");
+            // Redact usernames (assuming usernames are alphanumeric and between 3 and 20 characters)
+            message = System.Text.RegularExpressions.Regex.Replace(message, @"\b[a-zA-Z0-9]{3,20}\b", "[REDACTED]");
+            return message;
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Ladbon/cigarcert/security/code-scanning/6](https://github.com/Ladbon/cigarcert/security/code-scanning/6)

To fix the problem, we need to ensure that any sensitive information is protected before being logged. This can be achieved by redacting or encrypting sensitive data before it is passed to the logging methods. We will introduce a method to redact sensitive information and use it in the logging methods where sensitive data might be logged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
